### PR TITLE
Featuer/#15 game init

### DIFF
--- a/src/classes/managers/game.manager.js
+++ b/src/classes/managers/game.manager.js
@@ -1,0 +1,89 @@
+// gameSession별 모든 유저가 공유하는 정보 관리를 위한 매니저, 현재 위치정보, ping, 보스 몬스터 현재 체력 등...
+
+import GAME_OBJECT_TYPES from '../../constants/gameObjectTypes.js';
+import Base from '../models/gameObject/base.class.js';
+import Path from '../models/gameObject/path.class.js';
+import BaseManager from './base.manager.js';
+
+const BASE_MAX_HP = 100;
+const CANVAS = { width: 1500, heigth: 680 };
+
+class GameManager extends BaseManager {
+  constructor() {
+    super();
+    this.gameObjects = new Map();
+  }
+
+  addPlayer(playerId, ...args) {
+    this.gameObjects.set(playerId, new Map());
+
+    this.gameObjects.get(playerId).set(GAME_OBJECT_TYPES.OBJECT.PATH, new Path(args[0] ?? CANVAS));
+
+    const path = this.gameObjects.get(playerId).get(GAME_OBJECT_TYPES.OBJECT.PATH).path;
+    this.gameObjects
+      .get(playerId)
+      .set(
+        GAME_OBJECT_TYPES.OBJECT.BASE,
+        new Base(path[path.length - 1].x, path[path.length - 1].y, BASE_MAX_HP),
+      );
+    this.gameObjects.get(playerId).set(GAME_OBJECT_TYPES.OBJECT_ARRAY.TOWERS, []);
+    this.gameObjects.get(playerId).set(GAME_OBJECT_TYPES.OBJECT_ARRAY.MONSTERS, []);
+  }
+
+  addObject(playerId, type, object) {
+    if (this.gameObjects.has(playerId)) {
+      const playerObjects = this.gameObjects.get(playerId);
+      if (playerObjects.has(type)) {
+        if (Object.hasOwn(GAME_OBJECT_TYPES.OBJECT, type)) {
+          playerObjects.set(type, object);
+        } else if (Object.hasOwn(GAME_OBJECT_TYPES.OBJECT_ARRAY, type)) {
+          playerObjects.get(type).push(object);
+        }
+      }
+    }
+  }
+
+  removePlayer(playerId) {
+    if (this.gameObjects.has(playerId)) {
+      this.gameObjects.delete(playerId);
+    }
+  }
+
+  removeObject(playerId, type, objectIndex) {
+    if (this.gameObjects.has(playerId)) {
+      const playerObjects = this.gameObjects.get(playerId);
+      if (playerObjects.has(type)) {
+        if (Object.hasOwn(GAME_OBJECT_TYPES.OBJECT, type)) {
+          playerObjects.delete(type);
+        } else if (Object.hasOwn(GAME_OBJECT_TYPES.OBJECT_ARRAY, type)) {
+          const object = playerObjects.get(type).splice(objectIndex, 1);
+          return object;
+        }
+      }
+    }
+    return null;
+  }
+
+  getPlayer(playerId) {
+    if (this.gameObjects.has(playerId)) {
+      return this.gameObjects.get(playerId);
+    }
+    return null;
+  }
+
+  getObject(playerId, type) {
+    if (this.gameObjects.has(playerId)) {
+      const playerObjects = this.gameObjects.get(playerId);
+      if (playerObjects.has(type)) {
+        return playerObjects.get(type);
+      }
+    }
+    return null;
+  }
+
+  clearAll() {
+    this.gameObjects.clear();
+  }
+}
+
+export default GameManager;

--- a/src/classes/models/game.class.js
+++ b/src/classes/models/game.class.js
@@ -1,10 +1,12 @@
 import { foundMatchNotification } from '../../utils/notification/game.notification.js';
+import GameManager from '../managers/game.manager.js';
 // import IntervalManager from '../managers/interval.manager.js';
 
 class Game {
   constructor(id, users) {
     this.id = id;
     this.users = users;
+    this.gameManager = new GameManager();
     this.startGame();
     // this.intervalManger = new IntervalManager();
   }
@@ -16,18 +18,21 @@ class Game {
   removeUser(userId) {
     this.users = this.users.filter((user) => user.id !== userId);
     // this.intervalManger.removePlayer(userId);
+  }
 
-    if (this.users.length < MAX_PLAYERS) {
-      this.state = 'waiting';
-    }
+  initGame() {
+    this.users.forEach((user) => {
+      this.gameManager.addPlayer(user.id, user.canvas);
+    });
   }
 
   startGame() {
+    this.initGame();
     this.users.forEach((user) => {
-      const userData = 'userData'; // 해당 유저 게임 초기 설정 값(몬스터 경로, 초기 타워 위치 등)
+      const userData = this.gameManager.getPlayer(user.id); // 해당 유저 게임 초기 설정 값(몬스터 경로, 기지 위치 등)
       const opponentData = this.users
         .filter((opponent) => opponent !== user)
-        .map((opponent) => 'opponentData');
+        .map((opponent) => this.gameManager.getPlayer(opponent.id));
 
       foundMatchNotification(user.socket, userData, opponentData, this.id);
     });

--- a/src/classes/models/gameObject/base.class.js
+++ b/src/classes/models/gameObject/base.class.js
@@ -1,0 +1,16 @@
+class Base {
+  constructor(x, y, maxHp) {
+    this.x = x; // 기지 x 좌표
+    this.y = y; // 기지 y 좌표
+    this.hp = maxHp; // 기지의 현재 HP
+    this.maxHp = maxHp; // 기지의 최대 HP
+  }
+
+  // method 추가
+  takeDamage(amount) {
+    this.hp -= amount;
+    return this.hp <= 0; // 기지의 HP가 0 이하이면 true, 아니면 false
+  }
+}
+
+export default Base;

--- a/src/classes/models/gameObject/monster.class.js
+++ b/src/classes/models/gameObject/monster.class.js
@@ -1,0 +1,8 @@
+export class Monster {
+  constructor(level, monsterNumber) {
+    this.monsterNumber = monsterNumber; // 몬스터 번호
+    this.level = level; // 몬스터 레벨
+  }
+
+  // method 추가
+}

--- a/src/classes/models/gameObject/path.class.js
+++ b/src/classes/models/gameObject/path.class.js
@@ -1,0 +1,34 @@
+class Path {
+  constructor(canvas) {
+    this.path = this.generateRandomMonsterPath(canvas.width, canvas.height);
+  }
+
+  generateRandomMonsterPath(width, height) {
+    const path = [];
+    let currentX = 0;
+    let currentY = Math.floor(Math.random() * 21) + 500; // 500 ~ 520 범위의 y 시작
+
+    path.push({ x: currentX, y: currentY });
+
+    while (currentX < width) {
+      currentX += Math.floor(Math.random() * 100) + 50; // 50 ~ 150 범위의 x 증가
+      if (currentX > width) {
+        currentX = width;
+      }
+
+      currentY += Math.floor(Math.random() * 200) - 100; // -100 ~ 100 범위의 y 변경
+      if (currentY < 0) {
+        currentY = 0;
+      }
+      if (currentY > height) {
+        currentY = height;
+      }
+
+      path.push({ x: currentX, y: currentY });
+    }
+
+    return path;
+  }
+}
+
+export default Path;

--- a/src/classes/models/gameObject/tower.class.js
+++ b/src/classes/models/gameObject/tower.class.js
@@ -1,0 +1,11 @@
+class Tower {
+  constructor(x, y) {
+    this.x = x; // 타워 x 좌표
+    this.y = y; // 타워 y 좌표
+  }
+
+  // method 추가
+  // upgrade(){}
+}
+
+export default Tower;

--- a/src/classes/models/matching.class.js
+++ b/src/classes/models/matching.class.js
@@ -1,6 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
 import { addGameSession } from '../../session/game.session.js';
-import { startMatching } from '../../utils/notification/game.notification.js';
 
 const USERS_PER_GAME = 2;
 
@@ -11,7 +10,6 @@ class Matching {
 
   addUser(user) {
     this.users.push(user);
-    startMatching(user.socket);
     this.matchUsers();
   }
 

--- a/src/constants/gameObjectTypes.js
+++ b/src/constants/gameObjectTypes.js
@@ -1,0 +1,12 @@
+const GAME_OBJECT_TYPES = {
+  OBJECT: {
+    PATH: 'path',
+    BASE: 'base',
+  },
+  OBJECT_ARRAY: {
+    TOWERS: 'towers',
+    MONSTERS: 'monsters',
+  },
+};
+
+export default GAME_OBJECT_TYPES;

--- a/src/handlers/handlerMapping.js
+++ b/src/handlers/handlerMapping.js
@@ -1,5 +1,8 @@
+import startMatchingHandler from './startMatching.handler.js';
+
 const handlerMappings = {
   // 1: 함수이름,
+  2: startMatchingHandler,
 };
 
 export default handlerMappings;

--- a/src/handlers/helper.js
+++ b/src/handlers/helper.js
@@ -5,15 +5,15 @@ import handlerMappings from './handlerMapping.js';
 
 export const handleDisconnect = (socket, uuid) => {
   console.log(`User disconnected: ${socket.id}`);
+
+  const matchingSession = getMatchingSession();
+  matchingSession.removeUser(uuid);
 };
 
 export const handleConnection = async (socket, userUUID) => {
   console.log(`New user connected: ${userUUID} with socket ID ${socket.id}`);
 
   const user = addUser(socket, userUUID);
-
-  // const matchingSession = getMatchingSession();
-  // matchingSession.addUser(user);
 
   socket.emit('connection', { uuid: userUUID });
 };

--- a/src/handlers/helper.js
+++ b/src/handlers/helper.js
@@ -12,14 +12,14 @@ export const handleConnection = async (socket, userUUID) => {
 
   const user = addUser(socket, userUUID);
 
-  const matchingSession = getMatchingSession();
-  matchingSession.addUser(user);
+  // const matchingSession = getMatchingSession();
+  // matchingSession.addUser(user);
 
   socket.emit('connection', { uuid: userUUID });
 };
 
 export const handleEvent = async (io, socket, data) => {
-  if (!config.client.clientVersion !== data.clientVersion) {
+  if (config.client.version !== data.clientVersion) {
     // 만약 일치하는 버전이 없다면 response 이벤트로 fail 결과를 전송합니다.
     socket.emit('response', { status: 'fail', message: 'Client version mismatch' });
     return;

--- a/src/handlers/startMatching.handler.js
+++ b/src/handlers/startMatching.handler.js
@@ -1,0 +1,18 @@
+import { getMatchingSession } from '../session/matching.session.js';
+import { getUserById } from '../session/user.session.js';
+
+const startMatchingHandler = (userId, payload) => {
+  const user = getUserById(userId);
+  if (!user) {
+    return { status: 'fail', message: 'user not found' };
+  }
+
+  user.canvas = { width: payload.width, height: payload.height };
+
+  const matchingSession = getMatchingSession();
+  matchingSession.addUser(user);
+
+  return { status: 'success', message: 'start matching', timestamp: Date.now() };
+};
+
+export default startMatchingHandler;

--- a/src/utils/notification/game.notification.js
+++ b/src/utils/notification/game.notification.js
@@ -1,3 +1,5 @@
+import { convertMapToObject } from '../transform.js';
+
 export const sendNotification = (socket, payload, message, eventName = 'notification') => {
   socket.emit(eventName, { status: 'success', message, payload });
 };
@@ -9,8 +11,8 @@ export const startMatching = (socket) => {
 
 export const foundMatchNotification = (socket, userData, opponentData, gameId) => {
   const payload = {
-    userData,
-    opponentData,
+    userData: convertMapToObject(userData),
+    opponentData: convertMapToObject(opponentData),
     gameId,
   };
   return sendNotification(socket, payload, 'found matching', 'matchFound');

--- a/src/utils/notification/game.notification.js
+++ b/src/utils/notification/game.notification.js
@@ -4,11 +4,6 @@ export const sendNotification = (socket, payload, message, eventName = 'notifica
   socket.emit(eventName, { status: 'success', message, payload });
 };
 
-export const startMatching = (socket) => {
-  const payload = { timestamp: Date.now() };
-  return sendNotification(socket, payload, 'start matching');
-};
-
 export const foundMatchNotification = (socket, userData, opponentData, gameId) => {
   const payload = {
     userData: convertMapToObject(userData),

--- a/src/utils/transform.js
+++ b/src/utils/transform.js
@@ -14,3 +14,16 @@ export const toCamelCase = (obj) => {
   // 객체도 배열도 아닌 경우, 원본 값을 반환
   return obj;
 };
+
+export const convertMapToObject = (mapData) => {
+  if (Array.isArray(mapData)) {
+    return mapData.map((v) => convertMapToObject(v));
+  } else if (mapData !== null && typeof mapData === 'object' && mapData.constructor === Map) {
+    const object = {};
+    for (const [key, value] of mapData.entries()) {
+      object[key] = convertMapToObject(value);
+    }
+    return object;
+  }
+  return mapData;
+};


### PR DESCRIPTION
## #15 게임 초기화
### 주요 내용
🎉 add - 게임 초기화 기능
✨ update - 게임 초기 설정을 세션 내 각 유저에게 전달
✨ update - 유저 연결 종료 시 매칭 세션에서 제거
🩹 fix - 게임 매칭 시작 로직 변경

### 상세 내용
🎉 add - 게임 초기화 기능
- 게임 초기화 시 필요한 게임 오브젝트 class 생성(path, base, tower, monster)
- 게임 세션 내 각 유저의 게임 오브젝트 관리를 위한 GameMananger 생성

✨ update - 게임 초기 설정을 세션 내 각 유저에게 전달
- 게임 초기화 후 생성된 게임 오브젝트(경로, 기지)를 게임 세션 내 각 유저들에게 전달
- 클라이언트는 서버에서 전달 받은 초기 설정 값을 적용
- 게임 초기 설정 테스트를 위한 testCode 삭제(generateRandomMonsterPath, 그 외 초기 설정)
![image](https://github.com/user-attachments/assets/7156c65e-2a4d-4028-93ee-676b9dc6afd1)


✨ update - 유저 연결 종료 시 매칭 세션에서 제거

🩹 fix - 게임 매칭 시작 로직 변경
- 기존 : 
  - 서버와 연결되자마자 자동으로 서버에서 매칭이 시작됨
- 변경 : 
  - 서버와 연결된 후 서버에서 유저의 uuid를 받아 매칭 시작 이벤트를 발송(sendEvent(2,payload)), 서버에서 해당 이벤트를 받아 매칭을 시작
- 매칭 시작 이벤트 추가
startMatchingHandler, handlerId = 2